### PR TITLE
docs: fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Now that we are aware of our data model, lets look at how we will design/structu
 ## Auth
 /api/login
  - POST => login a user
+
 /api/register
  - POST => register a user
 


### PR DESCRIPTION
Break before each API endpoint URL in `README.md`